### PR TITLE
Fix syntax error in README default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ require'mason-tool-installer'.setup {
     -- will happen on startup. You can use :MasonToolsInstall or
     -- :MasonToolsUpdate to install tools and check for updates.
     -- Default: true
-    run_on_start = true
+    run_on_start = true,
 
     -- set a delay (in ms) before the installation starts. This is only
     -- effective if run_on_start is set to true.


### PR DESCRIPTION
This corrects the README, which has a tiny syntax error in the example config.