### PR TITLE
fix: Execute the autocmd when up-to-date

### DIFF
--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -69,21 +69,22 @@ local check_install = function(force_update)
           if ok and installed_version ~= version then
             do_install(p, version, on_close)
           else
-            completed = completed + 1
+            vim.schedule(on_close)
           end
         end)
       elseif
-        force_update or (force_update == nil and (auto_update or (auto_update == nil and SETTINGS.auto_update)))
+        force_update
+        or (force_update == nil and (auto_update or (auto_update == nil and SETTINGS.auto_update)))
       then
         p:check_new_version(function(ok, version)
           if ok then
             do_install(p, version.latest_version, on_close)
           else
-            completed = completed + 1
+            vim.schedule(on_close)
           end
         end)
       else
-        completed = completed + 1
+        vim.schedule(on_close)
       end
     else
       do_install(p, version, on_close)


### PR DESCRIPTION
If all plugins are up-to-date the `on_close` callback is never run and the `MasonToolsUpdateCompleted` autocmd is never executed. Calling the `on_close` function instead of just incrementing the number of completed updates guarantees that, regardless of whether the `do_install` function is called or not, the autocmd will be executed once we loop through all packages.