### PR TITLE
Add lspconfig name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ helps users keep up-to-date with their tools and to make certain they have a con
 This plugin has the same requirements as [Mason](https://github.com/williamboman/mason.nvim). And, of course,
 this plugin requires that Mason be installed.
 
+Optionally, [mason-lspconfig](https://github.com/williamboman/mason-lspconfig.nvim) can be installed for the
+option to use lspconfig names instead of Mason names.
+
 ## Installation
 
 Install using your favorite plugin manager.
@@ -30,6 +33,10 @@ git clone https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim
 ```
 
 ## Configuration
+
+When passing a list of tools to `ensure_installed`, `mason-tool-installer` is expecting Mason
+package names by default. If `mason-lspconfig` is installed, `mason-tool-installer` can accept
+`lspconfig` package names instead.
 
 ```lua
 require('mason-tool-installer').setup {

--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -1,4 +1,6 @@
 local mr = require 'mason-registry'
+local ok_mlsp, mlsp = pcall(require, 'mason-lspconfig')
+if not ok_mlsp then mlsp = nil end
 
 local SETTINGS = {
   ensure_installed = {},
@@ -113,6 +115,9 @@ local check_install = function(force_update)
         auto_update = item.auto_update
       else
         name = item
+      end
+      if mlsp then
+        name = mlsp.get_mappings().lspconfig_to_mason[name] or name
       end
       local p = mr.get_package(name)
       if p:is_installed() then


### PR DESCRIPTION
I found a [comment](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim/issues/3#issuecomment-1460695008) on #3 mentioning the idea of adding support for `lspconfig` names.

What's nice is that `mason-lspconfig` actually provides a mapping table for `mason` LSP names and `lspconfig` names and vice versa (`:h mason-lspconfig.get_mappings`). So while `mason-registry` only contains `mason` LSP names, simply checking the map for the appropriate `mason` name and then passing this new value does the job.

This change does make `mason-tool-installer` rely on `mason-lspconfig`, but if `mason-lpconfig` does not exist, the `lspconfig` name lookup is skipped. (I assume if you don't have `mason-lspconfig`, you aren't using `lspconfig` names anyway.)