### PR TITLE
Add support for null-ls and nvim-dap package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ helps users keep up-to-date with their tools and to make certain they have a con
 This plugin has the same requirements as [Mason](https://github.com/williamboman/mason.nvim). And, of course,
 this plugin requires that Mason be installed.
 
-Optionally, [mason-lspconfig](https://github.com/williamboman/mason-lspconfig.nvim) can be installed for the
-option to use lspconfig names instead of Mason names.
+Optionally:
+-   [mason-lspconfig](https://github.com/williamboman/mason-lspconfig.nvim) can be installed for the
+    option to use lspconfig names instead of Mason names.
+-   [mason-null-ls](https://github.com/jay-babu/mason-null-ls.nvim) can be installed for the
+    option to use null-ls names instead of Mason names.
+-   [mason-nvim-dap](https://github.com/jay-babu/mason-nvim-dap.nvim) can be installed for the
+    option to use nvim-dap names instead of Mason names.
 
 ## Installation
 
@@ -35,8 +40,13 @@ git clone https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim
 ## Configuration
 
 When passing a list of tools to `ensure_installed`, `mason-tool-installer` is expecting Mason
-package names by default. If `mason-lspconfig` is installed, `mason-tool-installer` can accept
-`lspconfig` package names instead.
+package names by default.
+
+If `mason-lspconfig` is installed, `mason-tool-installer` can accept `lspconfig` package names.
+
+If `mason-null-ls` is installed, `mason-tool-installer` can accept `null-ls` package names.
+
+If `mason-nvim-dap` is installed, `mason-tool-installer` can aceept `nvim-dap` package names.
 
 ```lua
 require('mason-tool-installer').setup {

--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -1,7 +1,18 @@
 local mr = require 'mason-registry'
+
 local ok_mlsp, mlsp = pcall(require, 'mason-lspconfig')
 if not ok_mlsp then
   mlsp = nil
+end
+
+local ok_mnls, mnls = pcall(require, 'mason-null-ls.mappings.source')
+if not ok_mnls then
+  mnls = nil
+end
+
+local ok_mdap, mdap = pcall(require, 'mason-nvim-dap.mappings.source')
+if not ok_mdap then
+  mdap = nil
 end
 
 local SETTINGS = {
@@ -123,6 +134,12 @@ local check_install = function(force_update, sync)
       end
       if mlsp then
         name = mlsp.get_mappings().lspconfig_to_mason[name] or name
+      end
+      if mnls then
+        name = mnls.getPackageFromNullLs(name) or name
+      end
+      if mdap then
+        name = mdap.nvim_dap_to_package[name] or name
       end
       local p = mr.get_package(name)
       if p:is_installed() then


### PR DESCRIPTION
This PR is similar in nature to https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim/pull/31 and solves a (slight) annoyance with trying to use `mason-tool-installer` in a way that merges all of the `ensure_installed` fields from `mason-lspconfig`, `mason-null-ls`, and `mason-nvim-dap`. An example of this can be seen [here](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/utility/mason-tool-installer-nvim). That same example also shows the current workaround for this problem -- we have to look up the plugin name <-> mason name mappings ourselves since `null-ls` and `nvim-dap` names cause issues for `mason-tool-installer`. It would be nice if `mason-tool-installer` did this by default. And, luckily for us, both `mason-null-ls` and `mason-nvim-dap` provide convenient mapping tables/functions.

On the downside, I did notice https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim/issues/42 and this PR only really makes that issue worse by adding two more (optional) dependencies in the same way that `mason-lspconfig` was added.