### PR TITLE
fix dap & null-ls names

### DIFF
--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -166,6 +166,12 @@ local check_install = function(force_update, sync)
       if mlsp then
         name = mlsp.get_mappings().lspconfig_to_mason[name] or name
       end
+      if mnls then
+        name = mnls.getPackageFromNullLs(name) or name
+      end
+      if mdap then
+        name = mdap.nvim_dap_to_package[name] or name
+      end
       local p = mr.get_package(name)
       if p:is_installed() then
         if version ~= nil then


### PR DESCRIPTION
It appears that after commit 4162124bd94f3018f520bd957474f7c2ab46962b, the name support for DAP and null-ls packages was lost (I had been unable to install DAPs myself).

It looks like the fix is to check for appropriate name mappings in `mnls` and `mdap` before calling `mr.get_package(name)`, as is done [below](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim/blob/374c78d3ebb5c53f43ea6bd906b6587b5e899b9e/lua/mason-tool-installer/init.lua#L162-L170).

Thanks for all the effort with this package!