### PR TITLE
fix: deprecated use of table argument for `vim.validate`

### DIFF
--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -42,19 +42,18 @@ end
 
 local setup = function(settings)
   SETTINGS = vim.tbl_deep_extend('force', SETTINGS, settings)
-  vim.validate {
-    ensure_installed = { SETTINGS.ensure_installed, 'table', true },
-    auto_update = { SETTINGS.auto_update, 'boolean', true },
-    run_on_start = { SETTINGS.run_on_start, 'boolean', true },
-    start_delay = { SETTINGS.start_delay, 'number', true },
-    debounce_hours = { SETTINGS.debounce_hours, 'number', true },
-    integrations = { SETTINGS.integrations, 'table', true },
-  }
-  vim.validate {
-    ['mason-lspconfig'] = { SETTINGS.integrations['mason-lspconfig'], 'boolean', true },
-    ['mason-null-ls'] = { SETTINGS.integrations['mason-null-ls'], 'boolean', true },
-    ['mason-nvim-dap'] = { SETTINGS.integrations['mason-nvim-dap'], 'boolean', true },
-  }
+
+  vim.validate('ensure_installed', SETTINGS.ensure_installed, 'table', true)
+  vim.validate('auto_update', SETTINGS.auto_update, 'boolean', true)
+  vim.validate('run_on_start', SETTINGS.run_on_start, 'boolean', true)
+  vim.validate('start_delay', SETTINGS.start_delay, 'number', true)
+  vim.validate('debounce_hours', SETTINGS.debounce_hours, 'number', true)
+  vim.validate('integrations', SETTINGS.integrations, 'table', true)
+
+  vim.validate('mason-lspconfig', SETTINGS.integrations['mason-lspconfig'], 'boolean', true)
+  vim.validate('mason-null-ls', SETTINGS.integrations['mason-null-ls'], 'boolean', true)
+  vim.validate('mason-nvim-dap', SETTINGS.integrations['mason-nvim-dap'], 'boolean', true)
+
   setup_integrations()
 end
 


### PR DESCRIPTION
Avoid using the deprecated table argument for `vim.validate` and instead call it multiple times, once for each value to validate.

This gets rid of the deprecation warning in Neovim 0.11.

Feel free to adjust the formatting. I was not sure whether to add newlines around the `vim.validate` calls.

Fixes https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim/issues/66