### PR TITLE
Fix nil error by using correct mapping based on version flag

### DIFF
--- a/lua/mason-tool-installer/init.lua
+++ b/lua/mason-tool-installer/init.lua
@@ -303,7 +303,11 @@ local clean = function()
       name = item
     end
     if mlsp then
-      name = mlsp.get_mappings().lspconfig_to_mason[name] or name
+      if IS_V1 then
+        name = mlsp.get_mappings().lspconfig_to_mason[name] or name
+      else
+        name = mlsp.get_mappings().lspconfig_to_package[name] or name
+      end
     end
     table.insert(expected, name)
   end


### PR DESCRIPTION
Use `lspconfig_to_mason` when `IS_V1` is true, otherwise use `lspconfig_to_package` to resolve name mappings correctly. This prevents runtime errors due to accessing nil values.