### PR TITLE
doc: improve go example condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ require('mason-tool-installer').setup {
     { 'bash-language-server', auto_update = true },
 
     -- you can do conditional installing
-    { 'gopls', condition = function() return not os.execute("go version") end },
+    { 'gopls', condition = function() return vim.fn.executable('go') == 1  end },
     'lua-language-server',
     'vim-language-server',
     'stylua',


### PR DESCRIPTION
I noticed that `os.execute("go version")` will always return a number and given that in Lua all numbers evaluate to `true` this condition always returns `false`.

From the docs:
```
os.execute([{command}])                                           *os.execute()*
        This function is equivalent to the C function `system`. It passes
        {command} to be executed by an operating system shell. It returns a
        status code, which is system-dependent. If {command} is absent, then
        it returns nonzero if a shell is available and zero otherwise.
```

Switching to `vim.fn.executable('go')` instead to check if the executable exists:

From the docs:
```
The result is a Number:
	1	exists
	0	does not exist
```