### PR TITLE
Use Mason Package Install Options

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,8 +1,13 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "workspace": {
-    "library": [
-      "$VIMRUNTIME",
-    ]
-  }
+    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+    "Lua.diagnostics.globals": [
+        "vim"
+    ],
+    "workspace": {
+        "library": [
+            "$VIMRUNTIME",
+            "~/.local/share/nvim-data/lazy/mason.nvim/lua",
+            "~/.local/share/nvim-data/lazy/mason-lspconfig.nvim/lua"
+        ]
+    }
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,13 +1,8 @@
 {
-    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-    "Lua.diagnostics.globals": [
-        "vim"
-    ],
-    "workspace": {
-        "library": [
-            "$VIMRUNTIME",
-            "~/.local/share/nvim-data/lazy/mason.nvim/lua",
-            "~/.local/share/nvim-data/lazy/mason-lspconfig.nvim/lua"
-        ]
-    }
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "workspace": {
+    "library": [
+      "$VIMRUNTIME",
+    ]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ require('mason-tool-installer').setup {
     -- you can turn off/on auto_update per tool
     { 'bash-language-server', auto_update = true },
 
+    -- you can set a specific arch, helpful if you have a win_arm64 processor.
+    { 'terraformls', target = "win_arm64" },
+    { 'lua_ls', target = "win_x64" },
+
     -- you can do conditional installing
-    { 'gopls', condition = function() return vim.fn.executable('go') == 1  end },
+    { 'gopls', condition = function() return vim.fn.executable('go') == 1 end },
     'lua-language-server',
     'vim-language-server',
     'stylua',


### PR DESCRIPTION
I was running into an issue with my ARM based PC. I am not quite sure what, but something was returning an unknown arch time on my Windows ARM. So, I wanted to give the ability expand install options and include the install options from Mason.

Now in addition to target, we can specify debug, target, force, strict, and even location.